### PR TITLE
add old seo urls

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -1,5 +1,7 @@
 const fs = require("fs")
 const getFilterPaths = require("./src/services/gridsomeFilterPaths")
+const getOldSeoPaths = require("./src/services/gridsomeOldSeoPaths")
+
 
 module.exports = function (api, filters) {
     api.loadSource(({
@@ -19,6 +21,14 @@ module.exports = function (api, filters) {
             path: "/:guid/job",
             component: "./src/templates/Job.vue"
         })
+
+        let oldSeoPaths = getOldSeoPaths()
+        for (let i = 0, len = oldSeoPaths.length; i < len; i++) {
+            createPage({
+                path: oldSeoPaths[i],
+                component: './src/pages/jobs.vue'
+            })
+        }
 
         let filterPaths = getFilterPaths()
         for (let i = 0, len = filterPaths.length; i < len; i++) {

--- a/src/constants/oldSeoPaths.js
+++ b/src/constants/oldSeoPaths.js
@@ -1,0 +1,17 @@
+const oldSeoPaths = {
+    TITLE: ["/:title/jobs-in"],
+    LOCATION: [
+        "/:country/jobs",
+        "/:state/:country/jobs",
+        "/:city/:state/:country/jobs"
+    ],
+    MOC: ["/:moc/vet-jobs"],
+    FILTERS: [
+        "/:filter/new-jobs",
+        "/:filter/:filter/new-jobs",
+        "/:filter/:filter/:filter/new-jobs"
+    ],
+    COMPANY: ["/:company/careers"]
+}
+
+module.exports = oldSeoPaths

--- a/src/services/gridsomeOldSeoPaths.js
+++ b/src/services/gridsomeOldSeoPaths.js
@@ -1,0 +1,30 @@
+const _ = require("lodash")
+const config = require("./../config.js")
+const oldSeoPaths = require("./../constants/oldSeoPaths.js")
+
+function buildOldSeoPaths(key, paths, builtPaths, builtKeys) {
+    builtPaths = _.union(builtPaths, paths)
+    for (const [currentKey, currentPaths] of Object.entries(oldSeoPaths)) {
+        if (currentKey !== key && !builtKeys.includes(currentKey)) {
+            for (let i = 0, len = currentPaths.length; i < len; i++) {
+                for (let j = 0, len = paths.length; j < len; j++) {
+                    builtPaths.push(`${paths[j]}${currentPaths[i]}`)
+                }
+            }
+        }
+    }
+    return builtPaths;
+}
+
+function getOldSeoPaths() {
+    let builtPaths = []
+    let builtKeys = []
+    for (const [key, paths] of Object.entries(oldSeoPaths)) {
+        builtPaths = _.union(buildOldSeoPaths(key, paths, builtPaths, builtKeys), builtPaths)
+        builtKeys.push(key)
+    }
+    return builtPaths
+}
+
+
+module.exports = getOldSeoPaths


### PR DESCRIPTION
These urls do not work... they just can exist for now. 

Actually http://localhost:8080/Sales%20Representative/jobs-in but it is an exact match which is the same behavior as http://localhost:8080/job-titles/Sales%20Representative/jobs. Need to work on further url slug formatting in another PR.

- only allows filters to be three levels deep
- builds the urls in the same order as old SEO urls
- adds and old url constant to be used in building the url combinations