### PR TITLE
Search filter component changes to render canonical urls. 

### DIFF
--- a/src/components/Search/AppSearchFilter.vue
+++ b/src/components/Search/AppSearchFilter.vue
@@ -1,9 +1,9 @@
 <template>
     <component
-        class="search-filter"
         :is="tag"
-        v-if="isVisible && hasOptions"
         v-bind="$attrs"
+        class="search-filter"
+        v-if="isVisible && hasOptions"
     >
         <h3 v-if="display" class="search-filter-display">
             Filter By {{ display }}
@@ -21,7 +21,7 @@
                     class="search-filter-options-item"
                     v-for="(option, index) in displayedFilters"
                 >
-                    <g-link :to="option.href">
+                    <g-link :to="option.link">
                         {{ option.display }}
                         <span v-if="option.value">({{ option.value }})</span>
                     </g-link>
@@ -32,20 +32,20 @@
                 v-if="shouldShowLess || shouldShowMore"
             >
                 <button
-                    class="search-filter-limiter-more"
+                    rel="nofollow"
                     @click="showMore()"
                     v-if="shouldShowMore"
                     aria-label="Show more filters"
-                    rel="nofollow"
+                    class="search-filter-limiter-more"
                 >
                     More
                 </button>
                 <button
-                    v-if="shouldShowLess"
+                    rel="nofollow"
                     @click="showLess()"
+                    v-if="shouldShowLess"
                     aria-label="Show less filters"
                     class="search-filter-limiter-less"
-                    rel="nofollow"
                 >
                     Less
                 </button>
@@ -84,6 +84,10 @@ export default {
             type: Boolean,
             default: true,
         },
+        preserveQueryParams: {
+            type: Boolean,
+            default: false,
+        },
         options: {
             required: false,
             type: Array,
@@ -111,11 +115,10 @@ export default {
         let value = null
         let filteredOptions = []
         this.givenOptions.forEach((option) => {
-            value = this.optionHasSubmitValue(option)
-                ? option.submit
-                : option.display
+            value = option.display
             if (this.input[this.name] != value) {
-                filteredOptions.push(this.buildFilterHref(option))
+                option.link = this.getOptionLink(option)
+                filteredOptions.push(option)
             }
         })
         this.displayedFilters = filteredOptions.slice(0, this.limit)
@@ -138,19 +141,12 @@ export default {
         },
     },
     methods: {
-        optionHasSubmitValue(option) {
-            return Object.prototype.hasOwnProperty.call(option, "submit")
-        },
-        buildFilterHref(option) {
-            let value = this.optionHasSubmitValue(option)
-                ? option.submit
-                : option.display
-            let params = {[this.name]: value}
-            if ("page" in this.$route.query) {
-                params.page = 1
+        getOptionLink(option){
+            if(!this.preserveQueryParams){
+                return option.link
             }
-            option.href = buildUrl("jobs", {...this.input, ...params})
-            return option
+
+            return buildUrl(option.link, {...this.$route.query, ...this.input})
         },
         showMore() {
             const numberOfItemsToAdd = this.limit

--- a/src/components/Search/AppSearchFilterChip.vue
+++ b/src/components/Search/AppSearchFilterChip.vue
@@ -25,7 +25,7 @@ export default {
             type: String,
             required: false,
             default() {
-                return this.$route.path
+                return '/jobs'
             },
         },
         input: {

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,3 @@
-const config = require("./configs/frontdoor.js")
+const config = require("./configs/sanfordhealth.js")
 
 module.exports = config

--- a/src/pages/jobs.vue
+++ b/src/pages/jobs.vue
@@ -155,6 +155,7 @@
                                 :key-name="configFilter.key"
                                 :visible="configFilter.visible"
                                 :options="getFilterOptions(configFilter)"
+                                :preserve-query-params="isCommuteSearch"
                             >
                                 <template
                                     v-slot="{
@@ -176,7 +177,7 @@
                                                     filter, index
                                                 ) in displayedFilters"
                                             >
-                                                <g-link :to="filter.href">
+                                                <g-link :to="filter.link">
                                                     {{ filter.display }}
                                                     <span v-if="filter.value">
                                                         ({{ filter.value }})


### PR DESCRIPTION
## What does this PR do?
* Makes changes to the `AppSearchFilter` component to render out links as built by the backend now (associated back end PR below)
* Change the default path of `AppSearchFilterChip` to `/jobs` instead of using the current path. I hit a navigation duplicated error because of the urls now being canonical and not using query params. 
* I couldnt get rid of query params entirely because of commute search (:sadparrot:) . Those params should stay present when performing a commute search so that the commute search doesnt switch to a regular search when selecting filters. This is now handled by a `preserveQueryParams` prop which determines whether or not to do this.



## Notes to Reviewer
Associated backend PR : https://github.com/DirectEmployers/microsites-search-api/pull/82

## Document Changes
There are changes to be made to docs but we need to talk about this once this hits production. We also need a reliable way to determine what all change as we merge qc to production. Something like the RRR and DDD we have in MyJobs. 
