### PR TITLE
Filter Canonical Urls

### DIFF
--- a/src/components/Search/AppSearchFilter.vue
+++ b/src/components/Search/AppSearchFilter.vue
@@ -1,9 +1,9 @@
 <template>
     <component
-        class="search-filter"
         :is="tag"
-        v-if="isVisible && hasOptions"
         v-bind="$attrs"
+        class="search-filter"
+        v-if="isVisible && hasOptions"
     >
         <h3 v-if="display" class="search-filter-display">
             Filter By {{ display }}
@@ -21,7 +21,7 @@
                     class="search-filter-options-item"
                     v-for="(option, index) in displayedFilters"
                 >
-                    <g-link :to="option.href">
+                    <g-link :to="option.link">
                         {{ option.display }}
                         <span v-if="option.value">({{ option.value }})</span>
                     </g-link>
@@ -32,20 +32,20 @@
                 v-if="shouldShowLess || shouldShowMore"
             >
                 <button
-                    class="search-filter-limiter-more"
+                    rel="nofollow"
                     @click="showMore()"
                     v-if="shouldShowMore"
                     aria-label="Show more filters"
-                    rel="nofollow"
+                    class="search-filter-limiter-more"
                 >
                     More
                 </button>
                 <button
-                    v-if="shouldShowLess"
+                    rel="nofollow"
                     @click="showLess()"
+                    v-if="shouldShowLess"
                     aria-label="Show less filters"
                     class="search-filter-limiter-less"
-                    rel="nofollow"
                 >
                     Less
                 </button>
@@ -84,6 +84,10 @@ export default {
             type: Boolean,
             default: true,
         },
+        preserveQueryParams: {
+            type: Boolean,
+            default: false,
+        },
         options: {
             required: false,
             type: Array,
@@ -111,11 +115,10 @@ export default {
         let value = null
         let filteredOptions = []
         this.givenOptions.forEach((option) => {
-            value = this.optionHasSubmitValue(option)
-                ? option.submit
-                : option.display
+            value = option.display
             if (this.input[this.name] != value) {
-                filteredOptions.push(this.buildFilterHref(option))
+                option.link = this.getOptionLink(option)
+                filteredOptions.push(option)
             }
         })
         this.displayedFilters = filteredOptions.slice(0, this.limit)
@@ -138,19 +141,12 @@ export default {
         },
     },
     methods: {
-        optionHasSubmitValue(option) {
-            return Object.prototype.hasOwnProperty.call(option, "submit")
-        },
-        buildFilterHref(option) {
-            let value = this.optionHasSubmitValue(option)
-                ? option.submit
-                : option.display
-            let params = {[this.name]: value}
-            if ("page" in this.$route.query) {
-                params.page = 1
+        getOptionLink(option){
+            if(!this.preserveQueryParams){
+                return option.link
             }
-            option.href = buildUrl("jobs", {...this.input, ...params})
-            return option
+
+            return buildUrl(option.link, {...this.$route.query, ...this.input})
         },
         showMore() {
             const numberOfItemsToAdd = this.limit

--- a/src/components/Search/AppSearchFilter.vue
+++ b/src/components/Search/AppSearchFilter.vue
@@ -116,10 +116,8 @@ export default {
         let filteredOptions = []
         this.givenOptions.forEach((option) => {
             value = option.display
-            if (this.input[this.name] != value) {
-                option.link = this.getOptionLink(option)
-                filteredOptions.push(option)
-            }
+            option.link = this.getOptionLink(option)
+            filteredOptions.push(option)
         })
         this.displayedFilters = filteredOptions.slice(0, this.limit)
     },

--- a/src/components/Search/Providers/mixins/provider.js
+++ b/src/components/Search/Providers/mixins/provider.js
@@ -131,11 +131,15 @@ export default {
         },
     },
     watch: {
-        //any time query string changes, update component input and search.
-        "$route.query"(newval, oldval) {
+        //any time route changes, update component input and search.
+        "$route"(newval, oldval) {
             this.jobDisplay = []
             this.isFirstLoad = true
-            this.input = this.mergeWithDefaultInput(this.$route.query)
+            this.input = this.mergeWithDefaultInput({
+                ...this.$route.query,
+                ...this.$route.params,
+            })
+
             this.queryChanged()
             this.extraData = this.defaultExtraData()
             this.search()
@@ -153,9 +157,7 @@ export default {
             ...this.$route.query,
             ...this.$route.params,
         })
-        if (!blank(this.$route.params.location)) {
-            this.input.location = displayLocationFromSlug(this.input.location)
-        }
+
         if (this.searchOnLoad) {
             this.search()
         }
@@ -220,12 +222,16 @@ export default {
             }
         },
         mergeWithDefaultInput(object = {}) {
-            return {
+            let input = {
                 ...this.getUrlFiltersObject({
                     ...this.defaultInput,
                     ...object
                 }),
             }
+            if (!blank(input.location)) {
+                input.location = displayLocationFromSlug(input.location)
+            }
+            return input
         },
         getUrlFiltersObject(object) {
             const filterSlugs = this.getConfigFilterSlugs()

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,3 @@
-const config = require("./configs/sanfordhealth.js")
+const config = require("./configs/boeing.js")
 
 module.exports = config

--- a/src/configs/boeing.js
+++ b/src/configs/boeing.js
@@ -1,0 +1,73 @@
+const config = {
+    buids: [48224],
+    source: "solr", //solr or google-talent
+    s3Folder: "boeingveterans-directemployer-works",
+    project_id: process.env.GRIDSOME_GOOGLE_TALENT_PROJECT_ID,
+    tenant_uuid: process.env.GRIDSOME_GOOGLE_TALENT_TENANT,
+    company_uuids: [process.env.GRIDSOME_GOOGLE_TALENT_COMPANY],
+    client_events: true, // Should be extracted to a separate config at some point
+    num_items: 2,
+    // featured_jobs: {
+    //     num_items: 10, //number of items per page.
+    //     solr: "reqid:(" + ["R-33091", "R-25218"].join(" OR ") + ")",
+    // },
+    // force_filters: {
+    //     solr:"title_exact:*Sales* OR title_exact:*Retail*"
+    // },
+    filters: [
+        {
+            name: "moc",
+            display: "MOC",
+        },
+        // {
+        //     name: "company",
+        //     display: "Company",
+        //     key: {
+        //         solr: "company",
+        //         google_talent: "employer"
+        //     }
+        // },
+        {
+            name: "schedule",
+            key: "schedule",
+            display: "Job Schedule",
+            solr_queries: {
+                "Full-Time": 'text:"Job Schedule: Full-Time"',
+                "PRN": 'text:"Job Schedule: PRN"',
+                "Part-Time": 'text:"Job Schedule: Part-Time"',
+                "Flex": 'text:"Flex"',
+            },
+        },
+        {
+            name: "shift",
+            display: "Shift",
+            solr_queries: {
+                "Varies": 'text:"Varies"',
+                "Day": 'text:"Day"',
+                "Rotating": 'text:"Rotating"',
+                "Evenings": 'text:"Shift: Evening" OR "- Evening Shift"'
+            },
+        },
+        {
+            name: "location",
+            key: "state",
+            display: "State"
+        },
+        {
+            name: "location",
+            key: "city",
+            display: "City",
+        },
+        {
+            name: "location",
+            key: "country",
+            display: "Country",
+        },
+        {
+            name: "title",
+            display: "Job Title",
+        },
+    ],
+}
+
+module.exports = config

--- a/src/configs/sanfordhealth.js
+++ b/src/configs/sanfordhealth.js
@@ -1,16 +1,16 @@
 const config = {
     buids: [19424],
-    source: "google-talent", //solr or google-talent
+    source: "solr", //solr or google-talent
     s3Folder: "sanfordhealth-jobs",
     project_id: process.env.GRIDSOME_GOOGLE_TALENT_PROJECT_ID,
     tenant_uuid: process.env.GRIDSOME_GOOGLE_TALENT_TENANT,
     company_uuids: [process.env.GRIDSOME_GOOGLE_TALENT_COMPANY],
     client_events: true, // Should be extracted to a separate config at some point
     num_items: 2,
-    featured_jobs: {
-        num_items: 10, //number of items per page.
-        solr: "reqid:(" + ["R-33091", "R-25218"].join(" OR ") + ")",
-    },
+    // featured_jobs: {
+    //     num_items: 10, //number of items per page.
+    //     solr: "reqid:(" + ["R-33091", "R-25218"].join(" OR ") + ")",
+    // },
     // force_filters: {
     //     solr:"title_exact:*Sales* OR title_exact:*Retail*"
     // },

--- a/src/pages/jobs.vue
+++ b/src/pages/jobs.vue
@@ -177,7 +177,7 @@
                                                     filter, index
                                                 ) in displayedFilters"
                                             >
-                                                <g-link :to="filter.href">
+                                                <g-link :to="filter.link">
                                                     {{ filter.display }}
                                                     <span v-if="filter.value">
                                                         ({{ filter.value }})

--- a/src/services/helpers.js
+++ b/src/services/helpers.js
@@ -64,9 +64,12 @@ const slugify = (string) => (
 
 export function displayLocationFromSlug(string) {
     if (string.indexOf("-") > -1) {
-        return words(toString(string)).reduce((result, word, index, original) => (
-            upperFirst(result + (index !== original.length - 1 ? " " + upperFirst(word) : ", " + word.toUpperCase()))
-        ))
+        return words(toString(string)).reduce(function(result, word, index, original){
+            if( word.length <= 3){
+                return upperFirst(result + (index !== original.length - 1 ? " " + upperFirst(word) : ", " +  word.toUpperCase()))
+            }
+            return upperFirst(`${result} ${upperFirst(word)}`)
+        })
     }
     return upperFirst(string);
 }


### PR DESCRIPTION
## What does this PR do?

* Makes changes to the `AppSearchFilter` component to render out links as built by the backend now.

* I couldnt get rid of query params entirely because of commute search (:sadparrot:) . Those params should stay present when performing a commute search so that the commute search doesnt switch to a regular search when selecting filters. This is now handled by a `preserveQueryParams` prop which determines whether or not to do this.

* Improve `displayLocationFromSlug` to not slug last word unless its 3 letters or less. I found that anything otherwise could up like this example: `united-states` -> `United STATES` 