### PR TITLE
updates API_URL to reflect changes to m8s-api

### DIFF
--- a/src/services/search.js
+++ b/src/services/search.js
@@ -13,7 +13,7 @@ export const GOOGLE_TALENT = "google_talent"
 let API_URL = "https://qc-search-api.jobsyn.org/api/v1/"
 
 if (process.env.GRIDSOME_USE_MINIKUBE === "true") {
-    API_URL = "http://minikube:35000/api/v1"
+    API_URL = "http://search-api.microsites.test/api/v1"
 } else if (!isDevelopment()) {
     API_URL = "https://prod-search-api.jobsyn.org/api/v1/"
 }


### PR DESCRIPTION
## What does this PR do?
The changes associated with updating NodePort services changes the minikube port and domain. From `minikube:35000` to `search-api.microsites.test`


## Notes to Reviewer
REF: https://github.com/DirectEmployers/microsites-search-api/pull/169